### PR TITLE
Some style fixes and stabilisation

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -42,8 +42,7 @@ impl Add<AddressDiff> for Address {
     fn add(self, AddressDiff(rhs): AddressDiff) -> Address {
         let Address(lhs) = self;
 
-        // TODO akeeton: Do a checked cast.
-        Address(((lhs as i32) + rhs) as u16)
+        Address(((i32::from(lhs)) + rhs) as u16)
     }
 }
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -448,7 +448,7 @@ impl CPU {
     fn shift_right_with_flags(p_val: &mut u8, status: &mut Status) {
         let mask = 1;
         let is_bit_0_set = (*p_val & mask) == mask;
-        *p_val = *p_val >> 1;
+        *p_val >>= 1;
         status.set_with_mask(
             PS_CARRY,
             Status::new(StatusArgs {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -109,17 +109,17 @@ impl CPU {
             }
 
             (Instruction::BCC, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 self.branch_if_carry_clear(addr);
             }
 
             (Instruction::BCS, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 self.branch_if_carry_set(addr);
             }
 
             (Instruction::BEQ, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 self.branch_if_equal(addr);
             }
 
@@ -149,23 +149,23 @@ impl CPU {
             }
 
             (Instruction::BMI, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 debug!("branch if minus relative. address: {:?}", addr);
                 self.branch_if_minus(addr);
             }
 
             (Instruction::BPL, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 self.branch_if_positive(addr);
             }
 
             (Instruction::BVC, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 self.branch_if_overflow_clear(addr);
             }
 
             (Instruction::BVS, OpInput::UseRelative(rel)) => {
-                let addr = self.registers.program_counter + AddressDiff(rel as i32);
+                let addr = self.registers.program_counter + AddressDiff(i32::from(rel));
                 self.branch_if_overflow_set(addr);
             }
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -139,7 +139,7 @@ pub enum AddressingMode {
 fn arr_to_addr(arr: &[u8]) -> Address {
     debug_assert!(arr.len() == 2);
 
-    let x = (arr[0] as u16) + ((arr[1] as u16) << 8usize);
+    let x = u16::from(arr[0]) + (u16::from(arr[1]) << 8usize);
     Address(x)
 }
 
@@ -187,19 +187,19 @@ impl AddressingMode {
                 // Use [u8, ..1] from instruction
                 // Interpret as zero page address
                 // (Output: an 8-bit zero-page address)
-                OpInput::UseAddress(Address(arr[0] as u16))
+                OpInput::UseAddress(Address(u16::from(arr[0])))
             }
             AddressingMode::ZeroPageX => {
                 // Use [u8, ..1] from instruction
                 // Add to X register (as u8 -- the final address is in 0-page)
                 // (Output: an 8-bit zero-page address)
-                OpInput::UseAddress(Address((arr[0] + x) as u16))
+                OpInput::UseAddress(Address(u16::from(arr[0] + x)))
             }
             AddressingMode::ZeroPageY => {
                 // Use [u8, ..1] from instruction
                 // Add to Y register (as u8 -- the final address is in 0-page)
                 // (Output: an 8-bit zero-page address)
-                OpInput::UseAddress(Address((arr[0] + y) as u16))
+                OpInput::UseAddress(Address(u16::from(arr[0] + y)))
             }
             AddressingMode::Relative => {
                 // Use [u8, ..1] from instruction
@@ -214,12 +214,12 @@ impl AddressingMode {
             AddressingMode::AbsoluteX => {
                 // Use [u8, ..2] from instruction as address, add X
                 // (Output: a 16-bit address)
-                OpInput::UseAddress(arr_to_addr(arr) + AddressDiff(x as i32))
+                OpInput::UseAddress(arr_to_addr(arr) + AddressDiff(i32::from(x)))
             }
             AddressingMode::AbsoluteY => {
                 // Use [u8, ..2] from instruction as address, add Y
                 // (Output: a 16-bit address)
-                OpInput::UseAddress(arr_to_addr(arr) + AddressDiff(y as i32))
+                OpInput::UseAddress(arr_to_addr(arr) + AddressDiff(i32::from(y)))
             }
             AddressingMode::Indirect => {
                 // Use [u8, ..2] from instruction as an address. Interpret the
@@ -234,7 +234,7 @@ impl AddressingMode {
                 // This is where the absolute (16-bit) target address is stored.
                 // (Output: a 16-bit address)
                 let start = arr[0] + x;
-                let slice = memory.get_slice(Address(start as u16), AddressDiff(2));
+                let slice = memory.get_slice(Address(u16::from(start)), AddressDiff(2));
                 OpInput::UseAddress(arr_to_addr(slice))
             }
             AddressingMode::IndirectIndexedY => {
@@ -243,8 +243,8 @@ impl AddressingMode {
                 // Add Y register to this address to get the final address
                 // (Output: a 16-bit address)
                 let start = arr[0];
-                let slice = memory.get_slice(Address(start as u16), AddressDiff(2));
-                OpInput::UseAddress(arr_to_addr(slice) + AddressDiff(y as i32))
+                let slice = memory.get_slice(Address(u16::from(start)), AddressDiff(2));
+                OpInput::UseAddress(arr_to_addr(slice) + AddressDiff(i32::from(y)))
             }
         }
     }

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -100,39 +100,39 @@ impl Status {
         let mut out = Status::empty();
 
         if negative {
-            out = out | PS_NEGATIVE
+            out |= PS_NEGATIVE
         }
         if overflow {
-            out = out | PS_OVERFLOW
+            out |= PS_OVERFLOW
         }
         if unused {
-            out = out | PS_UNUSED
+            out |= PS_UNUSED
         }
         if brk {
-            out = out | PS_BRK
+            out |= PS_BRK
         }
         if decimal_mode {
-            out = out | PS_DECIMAL_MODE
+            out |= PS_DECIMAL_MODE
         }
         if disable_interrupts {
-            out = out | PS_DISABLE_INTERRUPTS
+            out |= PS_DISABLE_INTERRUPTS
         }
         if zero {
-            out = out | PS_ZERO
+            out |= PS_ZERO
         }
         if carry {
-            out = out | PS_CARRY
+            out |= PS_CARRY
         }
 
         out
     }
 
     pub fn and(&mut self, rhs: Status) {
-        *self = *self & rhs;
+        *self &= rhs;
     }
 
     pub fn or(&mut self, rhs: Status) {
-        *self = *self | rhs;
+        *self |= rhs;
     }
 
     pub fn set_with_mask(&mut self, mask: Status, rhs: Status) {

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -146,7 +146,7 @@ pub struct StackPointer(pub u8);
 impl StackPointer {
     pub fn to_address(&self) -> Address {
         let StackPointer(sp) = *self;
-        STACK_ADDRESS_LO + AddressDiff(sp as i32)
+        STACK_ADDRESS_LO + AddressDiff(i32::from(sp))
     }
 
     // JAM: FIXME: Should we prevent overflow here? What would a 6502 do?


### PR DESCRIPTION
Related to #6.

Change some casts from `as` to a `TYPE::from(value)` style so that the compile can warn us in the future for some things. -- See also https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#cast_lossless

Simplify some expressions by using the assign op pattern. -- See also https://rust-lang-nursery.github.io/rust-clippy/v0.0.212/index.html#assign_op_pattern