### PR TITLE
add option to statically disable decimal mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: -F disable_decimal_mode
+          args: --no-default-features

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,3 +33,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+      - name: Run tests with disabled decimal mode
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: -F disable_decimal_mode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,3 +54,7 @@ skeptic = "0.13.7"
 
 [dev-dependencies]
 skeptic = "0.13.7"
+
+[features]
+disable_decimal_mode = []
+default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,5 +56,5 @@ skeptic = "0.13.7"
 skeptic = "0.13.7"
 
 [features]
-disable_decimal_mode = []
-default = []
+decimal_mode = []
+default = ["decimal_mode"]

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -546,11 +546,15 @@ impl CPU {
             0x00
         };
 
+        #[cfg(not(feature = "disable_decimal_mode"))]
         let result: i8 = if self.registers.status.contains(Status::PS_DECIMAL_MODE) {
             a_after.wrapping_add(bcd1).wrapping_add(bcd2)
         } else {
             a_after
         };
+
+        #[cfg(feature = "disable_decimal_mode")]
+        let result: i8 = a_after;
 
         let did_carry = (result as u8) < (a_before as u8) || (c_before == 1 && value == -1);
 
@@ -619,11 +623,15 @@ impl CPU {
             0x00
         };
 
+        #[cfg(not(feature = "disable_decimal_mode"))]
         let result: i8 = if self.registers.status.contains(Status::PS_DECIMAL_MODE) {
             a_after.wrapping_sub(bcd1).wrapping_sub(bcd2)
         } else {
             a_after
         };
+
+        #[cfg(feature = "disable_decimal_mode")]
+        let result: i8 = a_after;
 
         // The carry flag is set on unsigned overflow.
         let did_carry = (result as u8) > (a_before as u8);

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -546,14 +546,14 @@ impl CPU {
             0x00
         };
 
-        #[cfg(not(feature = "disable_decimal_mode"))]
+        #[cfg(feature = "decimal_mode")]
         let result: i8 = if self.registers.status.contains(Status::PS_DECIMAL_MODE) {
             a_after.wrapping_add(bcd1).wrapping_add(bcd2)
         } else {
             a_after
         };
 
-        #[cfg(feature = "disable_decimal_mode")]
+        #[cfg(not(feature = "decimal_mode"))]
         let result: i8 = a_after;
 
         let did_carry = (result as u8) < (a_before as u8) || (c_before == 1 && value == -1);
@@ -623,14 +623,14 @@ impl CPU {
             0x00
         };
 
-        #[cfg(not(feature = "disable_decimal_mode"))]
+        #[cfg(feature = "decimal_mode")]
         let result: i8 = if self.registers.status.contains(Status::PS_DECIMAL_MODE) {
             a_after.wrapping_sub(bcd1).wrapping_sub(bcd2)
         } else {
             a_after
         };
 
-        #[cfg(feature = "disable_decimal_mode")]
+        #[cfg(not(feature = "decimal_mode"))]
         let result: i8 = a_after;
 
         // The carry flag is set on unsigned overflow.
@@ -802,7 +802,7 @@ mod tests {
     use super::*;
     use num::range_inclusive;
 
-    #[cfg_attr(not(feature = "disable_decimal_mode"), test)]
+    #[cfg_attr(feature = "decimal_mode", test)]
     fn decimal_add_test() {
         let mut cpu = CPU::new();
         cpu.registers.status.or(Status::PS_DECIMAL_MODE);
@@ -829,7 +829,7 @@ mod tests {
         assert!(cpu.registers.status.contains(Status::PS_OVERFLOW));
     }
 
-    #[cfg_attr(not(feature = "disable_decimal_mode"), test)]
+    #[cfg_attr(feature = "decimal_mode", test)]
     fn decimal_subtract_test() {
         let mut cpu = CPU::new();
         cpu.registers

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -802,7 +802,7 @@ mod tests {
     use super::*;
     use num::range_inclusive;
 
-    #[test]
+    #[cfg_attr(not(feature = "disable_decimal_mode"), test)]
     fn decimal_add_test() {
         let mut cpu = CPU::new();
         cpu.registers.status.or(Status::PS_DECIMAL_MODE);
@@ -829,7 +829,7 @@ mod tests {
         assert!(cpu.registers.status.contains(Status::PS_OVERFLOW));
     }
 
-    #[test]
+    #[cfg_attr(not(feature = "disable_decimal_mode"), test)]
     fn decimal_subtract_test() {
         let mut cpu = CPU::new();
         cpu.registers


### PR DESCRIPTION
So I've never looked at conditional compilation before in Rust. Maybe I got something wrong here. But the tests still pass.