### PR TITLE
Add or subtract: some values result in panics

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -629,7 +629,8 @@ impl CPU {
         let over =
             ((nc == 0 && value < 0) || (nc == 1 && value < -1)) && a_before >= 0 && a_after < 0;
 
-        let under = (a_before < 0) && (-value - nc < 0) && a_after >= 0;
+        let under =
+            (a_before < 0) && (0i8.wrapping_sub(value).wrapping_sub(nc) < 0) && a_after >= 0;
 
         let did_overflow = over || under;
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -837,6 +837,15 @@ mod tests {
     use super::*;
     use num::range_inclusive;
 
+    #[test]
+    fn dont_panic_for_overflow() {
+        let mut cpu = CPU::new();
+        cpu.add_with_carry(-128);
+        assert_eq!(cpu.registers.accumulator, -128);
+        cpu.add_with_carry(-128);
+        assert_eq!(cpu.registers.accumulator, 0);
+    }
+
     #[cfg_attr(feature = "decimal_mode", test)]
     fn decimal_add_test() {
         let mut cpu = CPU::new();

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -845,6 +845,11 @@ mod tests {
         assert_eq!(cpu.registers.accumulator, -128);
         cpu.add_with_carry(-128);
         assert_eq!(cpu.registers.accumulator, 0);
+
+        cpu.subtract_with_carry(-128);
+        assert_eq!(cpu.registers.accumulator, -128);
+        cpu.subtract_with_carry(-128);
+        assert_eq!(cpu.registers.accumulator, 0);
     }
 
     #[cfg_attr(feature = "decimal_mode", test)]


### PR DESCRIPTION
This is to do with the overflow calculations. On line 632 for example

    let under = (a_before < 0) && (-value - nc < 0) && a_after >= 0;

it's going to panic when `value` is 0x80 because: 

```
thread 'main' panicked at 'attempt to negate with overflow', /home/somebody/.cargo/git/checkouts/mos6502-20f45e206a713ee7/11e48c1/src/cpu.rs:632:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```