### PR TITLE
bugfix for the bit opcode

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -237,10 +237,10 @@ impl<M: Bus> CPU<M> {
                 let is_zero = 0 == res;
 
                 // The N flag is set to bit 7 of the byte from memory.
-                let bit7 = 0 != (0x80 & res);
+                let bit7 = 0 != (0x80 & m);
 
                 // The V flag is set to bit 6 of the byte from memory.
-                let bit6 = 0 != (0x40 & res);
+                let bit6 = 0 != (0x40 & m);
 
                 self.registers.status.set_with_mask(
                     Status::PS_ZERO | Status::PS_NEGATIVE | Status::PS_OVERFLOW,


### PR DESCRIPTION
The bit opcode computes accumulator AND operand, and updates the Z flag. And it copies bits 6 and 7 from the operand into the flags register.

But what this *was* doing is copy bits 6 and 7 from the AND instead of directly from the operand.

This bug was discovered by solid65.