### PR TITLE
Fix the PHP opcode

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -427,7 +427,7 @@ impl<M: Bus> CPU<M> {
             }
             (Instruction::PHP, OpInput::UseImplied) => {
                 // Push status
-                let val = self.registers.status.bits();
+                let val = self.registers.status.bits() | 0x30;
                 self.push_on_stack(val);
             }
             (Instruction::PLA, OpInput::UseImplied) => {

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -1155,6 +1155,16 @@ mod tests {
     }
 
     #[test]
+    fn php_sets_bits_4_and_5() {
+        let mut cpu = CPU::new(Ram::new());
+        cpu.execute_instruction((Instruction::PHP, OpInput::UseImplied));
+        cpu.execute_instruction((Instruction::PLA, OpInput::UseImplied));
+        cpu.execute_instruction((Instruction::AND, OpInput::UseImmediate(0x30)));
+
+        assert_eq!(cpu.registers.accumulator, 0x30);
+    }
+
+    #[test]
     fn and_test() {
         let mut cpu = CPU::new(Ram::new());
 


### PR DESCRIPTION
PHP pushes the processor's register status to the stack. It needs to set the B flag as explained [here](https://www.nesdev.org/wiki/Status_flags#The_B_flag), and also needs to set bit 5 in the written memory value.