### PR TITLE
Implement the Indirect jmp bug for NMOS

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -150,7 +150,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                             address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()),
                         )
                     }
-                    AddressingMode::IndirectWithFix => {
+                    AddressingMode::Indirect => {
                         // Use [u8, ..2] from instruction as an address. Interpret the
                         // two bytes starting at that address as an address.
                         // (Output: a 16-bit address)

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -32,7 +32,6 @@ use crate::Variant;
 use crate::registers::{Registers, StackPointer, Status, StatusArgs};
 
 fn address_from_bytes(lo: u8, hi: u8) -> u16 {
-
     u16::from(lo) + (u16::from(hi) << 8usize)
 }
 
@@ -140,12 +139,16 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                     AddressingMode::AbsoluteX => {
                         // Use [u8, ..2] from instruction as address, add X
                         // (Output: a 16-bit address)
-                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]).wrapping_add(x.into()))
+                        OpInput::UseAddress(
+                            address_from_bytes(slice[0], slice[1]).wrapping_add(x.into()),
+                        )
                     }
                     AddressingMode::AbsoluteY => {
                         // Use [u8, ..2] from instruction as address, add Y
                         // (Output: a 16-bit address)
-                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()))
+                        OpInput::UseAddress(
+                            address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()),
+                        )
                     }
                     AddressingMode::IndirectWithFix => {
                         // Use [u8, ..2] from instruction as an address. Interpret the
@@ -165,11 +168,18 @@ impl<M: Bus, V: Variant> CPU<M, V> {
 
                         let low_byte_of_target = memory.get_byte(pointer);
 
-                        let low_byte_of_incremented_pointer = pointer.to_le_bytes()[0].wrapping_add(1);
-                        let incremented_pointer = u16::from_le_bytes([low_byte_of_incremented_pointer, pointer.to_le_bytes()[1]]);
+                        let low_byte_of_incremented_pointer =
+                            pointer.to_le_bytes()[0].wrapping_add(1);
+                        let incremented_pointer = u16::from_le_bytes([
+                            low_byte_of_incremented_pointer,
+                            pointer.to_le_bytes()[1],
+                        ]);
 
                         let high_byte_of_target = memory.get_byte(incremented_pointer);
-                        OpInput::UseAddress(address_from_bytes(low_byte_of_target, high_byte_of_target))
+                        OpInput::UseAddress(address_from_bytes(
+                            low_byte_of_target,
+                            high_byte_of_target,
+                        ))
                     }
                     AddressingMode::IndexedIndirectX => {
                         // Use [u8, ..1] from instruction
@@ -187,7 +197,9 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                         // (Output: a 16-bit address)
                         let start = slice[0];
                         let slice = read_address(memory, u16::from(start));
-                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()))
+                        OpInput::UseAddress(
+                            address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()),
+                        )
                     }
                 };
 

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -156,7 +156,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                         // (Output: a 16-bit address)
                         // TODO: If the pointer ends in 0xff, then incrementing it would propagate
                         // the carry to the high byte of the pointer. This incurs a cost of one
-                        // machine on the real 65C02, which is not implemented here.
+                        // machine instruction on the real 65C02, which is not implemented here.
                         let slice = read_address(memory, address_from_bytes(slice[0], slice[1]));
                         OpInput::UseAddress(address_from_bytes(slice[0], slice[1]))
                     }

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -31,10 +31,9 @@ use crate::Variant;
 
 use crate::registers::{Registers, StackPointer, Status, StatusArgs};
 
-fn arr_to_addr(arr: &[u8]) -> u16 {
-    debug_assert!(arr.len() == 2);
+fn address_from_bytes(lo: u8, hi: u8) -> u16 {
 
-    u16::from(arr[0]) + (u16::from(arr[1]) << 8usize)
+    u16::from(lo) + (u16::from(hi) << 8usize)
 }
 
 #[derive(Clone)]
@@ -136,17 +135,17 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                     AddressingMode::Absolute => {
                         // Use [u8, ..2] from instruction as address
                         // (Output: a 16-bit address)
-                        OpInput::UseAddress(arr_to_addr(&slice))
+                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]))
                     }
                     AddressingMode::AbsoluteX => {
                         // Use [u8, ..2] from instruction as address, add X
                         // (Output: a 16-bit address)
-                        OpInput::UseAddress(arr_to_addr(&slice).wrapping_add(x.into()))
+                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]).wrapping_add(x.into()))
                     }
                     AddressingMode::AbsoluteY => {
                         // Use [u8, ..2] from instruction as address, add Y
                         // (Output: a 16-bit address)
-                        OpInput::UseAddress(arr_to_addr(&slice).wrapping_add(y.into()))
+                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()))
                     }
                     AddressingMode::Indirect => {
                         // Use [u8, ..2] from instruction as an address. Interpret the
@@ -162,7 +161,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                         // (Output: a 16-bit address)
                         let start = slice[0].wrapping_add(x);
                         let slice = read_address(memory, u16::from(start));
-                        OpInput::UseAddress(arr_to_addr(&slice))
+                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]))
                     }
                     AddressingMode::IndirectIndexedY => {
                         // Use [u8, ..1] from instruction
@@ -171,7 +170,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                         // (Output: a 16-bit address)
                         let start = slice[0];
                         let slice = read_address(memory, u16::from(start));
-                        OpInput::UseAddress(arr_to_addr(&slice).wrapping_add(y.into()))
+                        OpInput::UseAddress(address_from_bytes(slice[0], slice[1]).wrapping_add(y.into()))
                     }
                 };
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -127,8 +127,8 @@ pub enum AddressingMode {
     Absolute,         // 3    JMP $1000    full 16-bit address
     AbsoluteX,        // 3    STA $1000,X  full 16-bit address plus X register
     AbsoluteY,        // 3    STA $1000,Y  full 16-bit address plus Y register
-    BuggyIndirect,    // 3    JMP ($1000)  jump to address stored at address
-    IndirectWithFix,  // 3    JMP ($1000)  jump to address stored at address
+    BuggyIndirect,    // 3    JMP ($1000)  jump to address stored at address, with the page-crossing bug founr in NMOS chips
+    Indirect,         // 3    JMP ($1000)  jump to address stored at address
     IndexedIndirectX, // 2    LDA ($10,X)  load from address stored at (constant
     //                   zero page address plus X register)
     IndirectIndexedY, // 2    LDA ($10),Y  load from (address stored at constant
@@ -148,7 +148,7 @@ impl AddressingMode {
             AddressingMode::Absolute => 2,
             AddressingMode::AbsoluteX => 2,
             AddressingMode::AbsoluteY => 2,
-            AddressingMode::IndirectWithFix => 2,
+            AddressingMode::Indirect => 2,
             AddressingMode::BuggyIndirect => 2,
             AddressingMode::IndexedIndirectX => 1,
             AddressingMode::IndirectIndexedY => 1,
@@ -476,7 +476,7 @@ impl crate::Variant for Cmos6502 {
     fn decode(opcode: u8) -> Option<(Instruction, AddressingMode)> {
         // TODO: We obviously need to add the other CMOS instructions here.
         match opcode {
-            0x6c => Some((Instruction::JMP, AddressingMode::IndirectWithFix)),
+            0x6c => Some((Instruction::JMP, AddressingMode::Indirect)),
             _ => Nmos6502::decode(opcode),
         }
     }

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -117,22 +117,47 @@ pub enum OpInput {
 
 #[derive(Copy, Clone)]
 pub enum AddressingMode {
-    Accumulator,      // 1    LSR A        work directly on accumulator
-    Implied,          // 1    BRK
-    Immediate,        // 2    LDA #10      8-bit constant in instruction
-    ZeroPage,         // 2    LDA $00      zero-page address
-    ZeroPageX,        // 2    LDA $80,X    address is X register + 8-bit constant
-    ZeroPageY,        // 2    LDX $10,Y    address is Y register + 8-bit constant
-    Relative,         // 2    BNE LABEL    branch target as signed relative offset
-    Absolute,         // 3    JMP $1000    full 16-bit address
-    AbsoluteX,        // 3    STA $1000,X  full 16-bit address plus X register
-    AbsoluteY,        // 3    STA $1000,Y  full 16-bit address plus Y register
-    BuggyIndirect,    // 3    JMP ($1000)  jump to address stored at address, with the page-crossing bug founr in NMOS chips
-    Indirect,         // 3    JMP ($1000)  jump to address stored at address
-    IndexedIndirectX, // 2    LDA ($10,X)  load from address stored at (constant
-    //                   zero page address plus X register)
-    IndirectIndexedY, // 2    LDA ($10),Y  load from (address stored at constant
-                      //                   zero page address) plus Y register
+    // work directly on accumulator, e. g. `lsr a`.
+    Accumulator,
+
+    // BRK
+    Implied,
+
+    // 8-bit constant in instruction, e. g. `lda #10`.
+    Immediate,
+
+    // zero-page address, e. g. `lda $00`.
+    ZeroPage,
+
+    // address is X register + 8-bit constant, e. g. `lda $80,x`.
+    ZeroPageX,
+
+    // address is Y register + 8-bit constant, e. g. `ldx $10,y`.
+    ZeroPageY,
+
+    // branch target as signed relative offset, e. g. `bne label`.
+    Relative,
+
+    // full 16-bit address, e. g. `jmp $1000`.
+    Absolute,
+
+    // full 16-bit address plus X register, e. g. `sta $1000,X`.
+    AbsoluteX,
+
+    // full 16-bit address plus Y register, e. g. `sta $1000,Y`.
+    AbsoluteY,
+
+    // jump to address stored at address, with the page-crossing bug found in NMOS chips, e. g. `jmp ($1000)`.
+    BuggyIndirect,
+
+    // jump to address stored at address, e. g. `jmp ($1000)`.
+    Indirect,
+
+    // load from address stored at (constant zero page address plus X register), e. g. `lda ($10,X)`.
+    IndexedIndirectX,
+
+    // load from (address stored at constant zero page address) plus Y register, e. g. `lda ($10),Y`.
+    IndirectIndexedY,
 }
 
 impl AddressingMode {

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -474,7 +474,7 @@ pub struct Cmos6502;
 
 impl crate::Variant for Cmos6502 {
     fn decode(opcode: u8) -> Option<(Instruction, AddressingMode)> {
-        // TODO: We obviously need to add the other CMOS isntructions here.
+        // TODO: We obviously need to add the other CMOS instructions here.
         match opcode {
             0x6c => Some((Instruction::JMP, AddressingMode::IndirectWithFix)),
             _ => Nmos6502::decode(opcode),


### PR DESCRIPTION
I've implemented the "hardware bug" that means NMOS CPUs read from the wrong address.

The "fixed version" is left in place, and is the basis for the CMOS variant's JMP indirect. It is correct except for one thing, and that's cycle accuracy.

closes #86 