### PR TITLE
impl Default for the Variant types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@
 name = "mos6502"
 description = "A MOS 6502 Emulator"
 license = "BSD-3-Clause"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["The 6502-rs Developers"]
 exclude = ["examples/**"]
 edition = "2021"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -35,7 +35,7 @@ fn address_from_bytes(lo: u8, hi: u8) -> u16 {
     u16::from(lo) + (u16::from(hi) << 8usize)
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CPU<M, V>
 where
     M: Bus,

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -311,7 +311,7 @@ impl AddressingMode {
 pub type DecodedInstr = (Instruction, OpInput);
 
 /// The NMOS 6502 variant. This one is present in the Commodore 64, early Apple IIs, etc.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Nmos6502;
 
 impl crate::Variant for Nmos6502 {
@@ -579,7 +579,7 @@ impl crate::Variant for Nmos6502 {
 
 /// The Ricoh variant which has no decimal mode. This is what to use if you want
 /// to emulate the NES.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Ricoh2a03;
 
 impl crate::Variant for Ricoh2a03 {
@@ -599,7 +599,7 @@ impl crate::Variant for Ricoh2a03 {
 
 /// Emulates some very early 6502s which have no ROR instruction. This one is used in very early
 /// KIM-1s.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct RevisionA;
 
 impl crate::Variant for RevisionA {
@@ -613,7 +613,7 @@ impl crate::Variant for RevisionA {
 }
 
 /// Emulates the 65C02, which has a few bugfixes, and another addressing mode
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub struct Cmos6502;
 
 impl crate::Variant for Cmos6502 {


### PR DESCRIPTION
For my particular use case it is convenient to have the Variant types impl Default; it could be good for the CPU also to do this. So I slapped the derive macro in a couple of places