### PR TITLE
Setup Dependabot for automatic dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
 version: 2
 updates:
-- package-ecosystem: cargo
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "04:00"
-  open-pull-requests-limit: 10
+  # Enable version updates for Cargo
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Add Dependabot configuration to automatically manage Rust dependencies
- Configure weekly updates for Cargo packages
- Limit concurrent PRs to 10 to avoid overwhelming the repository

## Configuration Details
- **Package ecosystem**: Cargo (Rust)
- **Update schedule**: Weekly
- **Directory**: Root directory (/)
- **PR limit**: 10 concurrent PRs
- **Commit message prefix**: `deps:`

This will help keep dependencies up to date automatically and reduce security vulnerabilities.