### PR TITLE
Improve SBC behavior for all 6502 variants

### DIFF
--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -680,7 +680,7 @@ impl crate::Variant for Nmos6502 {
         // SBC performs: A = A - M - (1 - C)
         // Which is equivalent to: A = A + (~M) + C (using two's complement)
         let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
-        
+
         // Check for borrow (unsigned underflow)
         let did_borrow = temp_result > accumulator;
         let did_carry = !did_borrow; // Carry is inverse of borrow in SBC
@@ -832,7 +832,7 @@ impl crate::Variant for Ricoh2a03 {
     fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
         // Ricoh2a03 (NES) always uses binary arithmetic
         let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
-        
+
         // Check for borrow (unsigned underflow)
         let did_borrow = temp_result > accumulator;
         let did_carry = !did_borrow; // Carry is inverse of borrow in SBC
@@ -1089,7 +1089,7 @@ impl crate::Variant for Cmos6502 {
     fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
         // Binary subtraction with borrow handling
         let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
-        
+
         // Check for borrow (unsigned underflow)
         let did_borrow = temp_result > accumulator;
         let did_carry = !did_borrow; // Carry is inverse of borrow in SBC

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -666,6 +666,99 @@ impl crate::Variant for Nmos6502 {
             zero,
         }
     }
+
+    /// NMOS 6502 SBC (Subtract with Carry) implementation in binary mode
+    ///
+    /// - Standard binary subtraction with borrow handling
+    /// - All flags calculated from binary result
+    ///
+    /// # References
+    ///
+    /// - [6502.org SBC documentation](http://www.6502.org/tutorials/decimal_mode.html)
+    /// - [NESdev 6502 reference](https://www.nesdev.org/obelisk-6502-guide/reference.html#SBC)
+    fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // SBC performs: A = A - M - (1 - C)
+        // Which is equivalent to: A = A + (~M) + C (using two's complement)
+        let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
+        
+        // Check for borrow (unsigned underflow)
+        let did_borrow = temp_result > accumulator;
+        let did_carry = !did_borrow; // Carry is inverse of borrow in SBC
+
+        // Calculate overflow: occurs when signs of A and M are different,
+        // and the result has a different sign than A
+        let overflow = (accumulator ^ value) & (accumulator ^ temp_result) & 0x80 != 0;
+
+        // Calculate other flags
+        let negative = (temp_result & 0x80) != 0;
+        let zero = temp_result == 0;
+
+        AdcOutput {
+            result: temp_result,
+            did_carry,
+            overflow,
+            negative,
+            zero,
+        }
+    }
+
+    /// NMOS 6502 SBC implementation in decimal mode (BCD)
+    ///
+    /// - Binary Coded Decimal (BCD) subtraction using 4-bit decimal digits
+    /// - Each nibble represents a digit from 0-9
+    /// - In decimal mode: N and Z flags are unreliable/undefined (NMOS behavior)
+    /// - V flag calculated from binary result (even in decimal mode)
+    ///
+    /// # References
+    ///
+    /// - [6502.org SBC documentation](http://www.6502.org/tutorials/decimal_mode.html)
+    /// - [NESdev 6502 reference](https://www.nesdev.org/obelisk-6502-guide/reference.html#SBC)
+    fn sbc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // Perform binary subtraction first for overflow calculation
+        let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
+
+        // Decimal mode: treat each nibble as a decimal digit (0-9)
+        let mut low_nibble = (accumulator & 0x0f)
+            .wrapping_sub(value & 0x0f)
+            .wrapping_sub(1 - carry_set);
+        let mut high_nibble = (accumulator >> 4).wrapping_sub(value >> 4);
+        let mut borrow = false;
+
+        // If low nibble underflowed (bit 4 set), correct it and set borrow
+        if (low_nibble & 0x10) != 0 {
+            low_nibble = (low_nibble.wrapping_add(10)) & 0x0f;
+            borrow = true;
+        }
+
+        // Subtract borrow from high nibble
+        high_nibble = high_nibble.wrapping_sub(u8::from(borrow));
+
+        // If high nibble underflowed, correct it and set final borrow
+        if (high_nibble & 0x10) != 0 {
+            high_nibble = (high_nibble.wrapping_add(10)) & 0x0f;
+            borrow = true;
+        } else {
+            borrow = false;
+        }
+
+        let result = (high_nibble << 4) | low_nibble;
+        let did_carry = !borrow; // Carry is inverse of borrow
+
+        // Calculate overflow from binary result (even in decimal mode)
+        let overflow = (accumulator ^ value) & (accumulator ^ temp_result) & 0x80 != 0;
+
+        // Calculate other flags from final result
+        let negative = (result & 0x80) != 0;
+        let zero = result == 0;
+
+        AdcOutput {
+            result,
+            did_carry,
+            overflow,
+            negative,
+            zero,
+        }
+    }
 }
 
 /// The Ricoh variant which has no decimal mode. This is what to use if you want
@@ -727,6 +820,50 @@ impl crate::Variant for Ricoh2a03 {
     fn adc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
         Self::adc_binary(accumulator, value, carry_set)
     }
+
+    /// `Ricoh2A03` (NES) SBC implementation in binary mode
+    ///
+    /// - Always performs binary subtraction
+    /// - All flags (N, Z, V, C) behave consistently like binary mode
+    /// - Used in Nintendo Entertainment System (NES) and Famicom
+    ///
+    /// # References
+    /// - [NESdev Ricoh2A03 reference](https://www.nesdev.org/wiki/CPU)
+    fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // Ricoh2a03 (NES) always uses binary arithmetic
+        let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
+        
+        // Check for borrow (unsigned underflow)
+        let did_borrow = temp_result > accumulator;
+        let did_carry = !did_borrow; // Carry is inverse of borrow in SBC
+
+        // Calculate overflow
+        let overflow = (accumulator ^ value) & (accumulator ^ temp_result) & 0x80 != 0;
+
+        // Calculate other flags
+        let negative = (temp_result & 0x80) != 0;
+        let zero = temp_result == 0;
+
+        AdcOutput {
+            result: temp_result,
+            did_carry,
+            overflow,
+            negative,
+            zero,
+        }
+    }
+
+    /// `Ricoh2A03` (NES) SBC implementation - decimal mode not supported
+    ///
+    /// The `Ricoh2A03` removed the decimal mode circuitry entirely to save cost,
+    /// so BCD operations are not supported. This method calls `sbc_binary` instead.
+    ///
+    /// # References
+    /// - [NESdev Ricoh2A03 reference](https://www.nesdev.org/wiki/CPU)
+    fn sbc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // Ricoh2a03 (NES) has no decimal mode, so always use binary arithmetic
+        Self::sbc_binary(accumulator, value, carry_set)
+    }
 }
 
 /// Emulates some very early 6502s which have no ROR instruction. This one is used in very early
@@ -773,6 +910,38 @@ impl crate::Variant for RevisionA {
     fn adc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
         // RevisionA behaves the same as NMOS 6502 for ADC
         Nmos6502::adc_decimal(accumulator, value, carry_set)
+    }
+
+    /// Revision A 6502 SBC implementation in binary mode
+    ///
+    /// - Identical SBC behavior to NMOS 6502
+    /// - Found in very early 6502 processors (KIM-1, etc.)
+    ///
+    /// # References:
+    ///
+    /// - [Rev. A 6502 (Pre-June 1976) "ROR Bug"](https://www.masswerk.at/6502/6502_instruction_set.html#ror-bug)
+    fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // RevisionA behaves the same as NMOS 6502 for SBC
+        Nmos6502::sbc_binary(accumulator, value, carry_set)
+    }
+
+    /// Revision A 6502 SBC implementation in decimal mode (BCD)
+    ///
+    /// - Identical SBC behavior to NMOS 6502
+    /// - Supports decimal (BCD) mode with same flag behavior as NMOS
+    /// - Found in very early 6502 processors (KIM-1, etc.)
+    ///
+    /// # Difference from NMOS 6502
+    ///
+    /// `RevisionA` lacks the ROR (Rotate Right) instruction entirely, but SBC
+    /// behavior is identical to the standard NMOS 6502.
+    ///
+    /// # References:
+    ///
+    /// - [Rev. A 6502 (Pre-June 1976) "ROR Bug"](https://www.masswerk.at/6502/6502_instruction_set.html#ror-bug)
+    fn sbc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // RevisionA behaves the same as NMOS 6502 for SBC
+        Nmos6502::sbc_decimal(accumulator, value, carry_set)
     }
 }
 
@@ -893,6 +1062,103 @@ impl crate::Variant for Cmos6502 {
 
         // Calculate overflow from binary result (even in decimal mode)
         let overflow = (!(accumulator ^ value) & (accumulator ^ temp_result)) & 0x80 != 0;
+
+        // On 65C02, N and Z flags are valid in decimal mode (calculated from BCD result)
+        // V flag behavior is still undocumented but calculated from binary result
+        let negative = (result & 0x80) != 0;
+        let zero = result == 0;
+
+        AdcOutput {
+            result,
+            did_carry,
+            overflow,
+            negative,
+            zero,
+        }
+    }
+
+    /// 65C02 (CMOS) SBC implementation in binary mode
+    ///
+    /// - Standard binary subtraction with borrow handling
+    /// - All flags calculated from binary result
+    ///
+    /// # References
+    ///
+    /// - [65C02 Programming Manual](http://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf)
+    /// - [6502.org CMOS differences](http://www.6502.org/tutorials/65c02opcodes.html)
+    fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // Binary subtraction with borrow handling
+        let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
+        
+        // Check for borrow (unsigned underflow)
+        let did_borrow = temp_result > accumulator;
+        let did_carry = !did_borrow; // Carry is inverse of borrow in SBC
+
+        // Calculate overflow
+        let overflow = (accumulator ^ value) & (accumulator ^ temp_result) & 0x80 != 0;
+
+        // Calculate other flags
+        let negative = (temp_result & 0x80) != 0;
+        let zero = temp_result == 0;
+
+        AdcOutput {
+            result: temp_result,
+            did_carry,
+            overflow,
+            negative,
+            zero,
+        }
+    }
+
+    /// 65C02 (CMOS) SBC implementation in decimal mode (BCD)
+    ///
+    /// - Supports decimal (BCD) mode with **corrected flag behavior**
+    /// - In decimal mode: N and Z flags are **reliable** (calculated from BCD result)
+    /// - V flag calculated from binary result (even in decimal mode)
+    /// - In decimal mode: **Extra cycle** consumed (not implemented in this emulator yet)
+    ///
+    /// # Difference from NMOS 6502
+    ///
+    /// The 65C02 fixed the unreliable N and Z flags in decimal mode. These flags
+    /// now correctly reflect the BCD result, making decimal arithmetic more predictable.
+    ///
+    /// # References
+    ///
+    /// - [65C02 Programming Manual](http://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf)
+    /// - [6502.org CMOS differences](http://www.6502.org/tutorials/65c02opcodes.html)
+    fn sbc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput {
+        // Perform binary subtraction first for overflow calculation
+        let temp_result = accumulator.wrapping_sub(value).wrapping_sub(1 - carry_set);
+
+        // Decimal mode: treat each nibble as a decimal digit (0-9)
+        let mut low_nibble = (accumulator & 0x0f)
+            .wrapping_sub(value & 0x0f)
+            .wrapping_sub(1 - carry_set);
+        let mut high_nibble = (accumulator >> 4).wrapping_sub(value >> 4);
+        let mut borrow = false;
+
+        // If low nibble underflowed (bit 4 set), correct it and set borrow
+        if (low_nibble & 0x10) != 0 {
+            low_nibble = (low_nibble.wrapping_add(10)) & 0x0f;
+            borrow = true;
+        }
+
+        // Subtract borrow from high nibble
+        high_nibble = high_nibble.wrapping_sub(u8::from(borrow));
+
+        // If high nibble underflowed, correct it and set final borrow
+        if (high_nibble & 0x10) != 0 {
+            high_nibble = (high_nibble.wrapping_add(10)) & 0x0f;
+            borrow = true;
+        } else {
+            borrow = false;
+        }
+
+        let result = (high_nibble << 4) | low_nibble;
+        let did_carry = !borrow; // Carry is inverse of borrow
+
+        // Calculate overflow from binary result (even in decimal mode)
+        let overflow = (accumulator ^ value) & (accumulator ^ temp_result) & 0x80 != 0;
 
         // On 65C02, N and Z flags are valid in decimal mode (calculated from BCD result)
         // V flag behavior is still undocumented but calculated from binary result

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,4 +96,26 @@ pub trait Variant {
     /// # Returns
     /// Tuple of (result, `carry_out`, overflow, negative, zero)
     fn adc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput;
+
+    /// Execute Subtract with Carry (SBC) in binary mode
+    ///
+    /// # Arguments
+    /// * `accumulator` - Current accumulator value
+    /// * `value` - Value to subtract  
+    /// * `carry_set` - Carry flag set at the time of execution (0 or 1)
+    ///
+    /// # Returns
+    /// Tuple of (result, `carry_out`, overflow, negative, zero)
+    fn sbc_binary(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput;
+
+    /// Execute Subtract with Carry (SBC) in decimal mode (BCD)
+    ///
+    /// # Arguments
+    /// * `accumulator` - Current accumulator value
+    /// * `value` - Value to subtract  
+    /// * `carry_set` - Carry flag set at the time of execution (0 or 1)
+    ///
+    /// # Returns
+    /// Tuple of (result, `carry_out`, overflow, negative, zero)
+    fn sbc_decimal(accumulator: u8, value: u8, carry_set: u8) -> AdcOutput;
 }


### PR DESCRIPTION
Follow-up to #109. 

This adds proper SBC (Subtract with Carry) implementations for all 6502 variants - NMOS 6502, Ricoh2A03 (NES), RevisionA, and 65C02. Each variant now has dedicated sbc_binary and sbc_decimal methods that handle the subtle differences in flag behavior and decimal mode support.

The implementations are thoroughly documented with references to official processor manuals and behavior notes for each variant.