### PR TITLE
Add HuC6280 timing hooks

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -173,6 +173,11 @@ impl<M: Bus, V: Variant> CPU<M, V> {
         }
     }
 
+    fn add_cycles(&mut self, cycles: u64) {
+        self.cycles = self.cycles.wrapping_add(cycles);
+        self.memory.tick(cycles);
+    }
+
     /// Perform the 6502 reset sequence
     ///
     /// The reset sequence on a 6502 is an 8-cycle process that simulates the same sequence
@@ -593,7 +598,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
         // Calculate and track cycles for this instruction
         let total_cycles =
             Self::calculate_instruction_cycles(instr, mode, operand.page_crossed(), self.registers);
-        self.cycles = self.cycles.wrapping_add(u64::from(total_cycles));
+        self.add_cycles(u64::from(total_cycles));
 
         match (instr, operand) {
             (Instruction::ADC, OpInput::UseImmediate(val)) => {
@@ -1495,6 +1500,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
         for _ in 0..count {
             let val = self.memory.get_byte(s);
             self.memory.set_byte(d, val);
+            self.add_cycles(6);
             s = Self::advance_block_pointer(s, src_step, &mut s_toggle);
             d = Self::advance_block_pointer(d, dest_step, &mut d_toggle);
         }
@@ -1505,9 +1511,6 @@ impl<M: Bus, V: Variant> CPU<M, V> {
         self.registers.index_x = self.pull_from_stack();
         self.registers.accumulator = self.pull_from_stack();
         self.registers.index_y = self.pull_from_stack();
-
-        // 6 cycles per byte copied (fixed overhead is in `base_cycles`).
-        self.cycles = self.cycles.wrapping_add(6 * u64::from(count));
     }
 
     /// Advance one block-transfer pointer by a single step.
@@ -1561,7 +1564,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                     // advance a cycle (and poll for an interrupt that might
                     // recover the CPU) instead of stalling a host that paces
                     // off the cycle count.
-                    self.cycles = self.cycles.wrapping_add(1);
+                    self.add_cycles(1);
                     self.check_interrupts(irq_enabled);
                     false
                 }
@@ -1571,7 +1574,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                 // IRQ/NMI, so burn a cycle and poll for the interrupt that
                 // wakes it. Without this a host pacing off cycles never lets
                 // time advance, so the interrupt never arrives (deadlock).
-                self.cycles = self.cycles.wrapping_add(1);
+                self.add_cycles(1);
                 let irq_enabled = !self
                     .registers
                     .status
@@ -1583,7 +1586,7 @@ impl<M: Bus, V: Variant> CPU<M, V> {
                 // STP/JAM - halted until reset. The clock still advances, so
                 // burn a cycle to keep pacing hosts progressing; use
                 // `wait_state()` to detect this and reset deliberately.
-                self.cycles = self.cycles.wrapping_add(1);
+                self.add_cycles(1);
                 false
             }
         }
@@ -2000,9 +2003,10 @@ impl<M: Bus, V: Variant> CPU<M, V> {
     }
 
     fn branch(&mut self, addr: u16) {
-        // +1 cycle for branch taken, +1 more if page boundary crossed
-        let page_crossed = (self.registers.program_counter ^ addr) & 0xFF00 != 0;
-        self.cycles += 1 + u64::from(page_crossed);
+        self.add_cycles(V::branch_taken_extra_cycles(
+            self.registers.program_counter,
+            addr,
+        ));
         self.registers.program_counter = addr;
     }
 
@@ -2129,6 +2133,8 @@ impl<M: Bus, V: Variant> CPU<M, V> {
     ///
     /// - [W65C02S Datasheet, Section 3.4 (IRQB) and 3.6 (NMIB)](https://www.westerndesigncenter.com/wdc/documentation/w65c02s.pdf)
     fn service_interrupt(&mut self, vector_addr: u16) {
+        self.add_cycles(V::interrupt_dispatch_cycles());
+
         // Push PC high byte, then low byte
         self.push_address(self.registers.program_counter);
 

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1993,6 +1993,14 @@ impl crate::Variant for Huc6280 {
         1 // Fixes the NMOS page-crossing bug and takes 6 cycles like the 65C02
     }
 
+    fn branch_taken_extra_cycles(_from: u16, _to: u16) -> u64 {
+        2
+    }
+
+    fn interrupt_dispatch_cycles() -> u64 {
+        8
+    }
+
     fn zero_page_base() -> u16 {
         0x2000 // Zero page lives at $2000-$20FF (via MPR1)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,18 @@ pub trait Variant {
         0 // Default: no penalty
     }
 
+    /// Extra cycles charged after a relative branch is taken.
+    #[must_use]
+    fn branch_taken_extra_cycles(from: u16, to: u16) -> u64 {
+        1 + u64::from((from ^ to) & 0xFF00 != 0)
+    }
+
+    /// Cycles charged when a hardware interrupt is serviced after an instruction.
+    #[must_use]
+    fn interrupt_dispatch_cycles() -> u64 {
+        0
+    }
+
     /// Base address of the zero page for this variant.
     ///
     /// Standard 6502 family parts place the zero page at `$0000`. The `HuC6280`

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -77,6 +77,13 @@ impl Default for Memory {
 /// assert_eq!(memory.get_byte(0x0000), 0x12);
 /// ```
 pub trait Bus {
+    /// Called whenever the CPU advances by `cycles`.
+    ///
+    /// Most memory implementations can ignore this. Systems with devices on the
+    /// CPU bus can override it to keep timers, video chips, or DMA engines in
+    /// sync with instruction execution.
+    fn tick(&mut self, _cycles: u64) {}
+
     /// Returns the byte at the given address.
     fn get_byte(&mut self, address: u16) -> u8;
 

--- a/tests/huc6280_timing.rs
+++ b/tests/huc6280_timing.rs
@@ -1,0 +1,104 @@
+use mos6502::cpu::CPU;
+use mos6502::instruction::{Huc6280, Nmos6502};
+use mos6502::memory::Bus;
+use mos6502::registers::Status;
+
+#[derive(Clone)]
+struct TickBus {
+    mem: [u8; 0x10000],
+    ticks: Vec<u64>,
+    irq: bool,
+}
+
+impl Default for TickBus {
+    fn default() -> Self {
+        Self {
+            mem: [0; 0x10000],
+            ticks: Vec::new(),
+            irq: false,
+        }
+    }
+}
+
+impl TickBus {
+    fn with_program(program: &[u8]) -> Self {
+        let mut bus = Self::default();
+        bus.mem[..program.len()].copy_from_slice(program);
+        bus
+    }
+}
+
+impl Bus for TickBus {
+    fn tick(&mut self, cycles: u64) {
+        self.ticks.push(cycles);
+    }
+
+    fn get_byte(&mut self, address: u16) -> u8 {
+        self.mem[address as usize]
+    }
+
+    fn set_byte(&mut self, address: u16, value: u8) {
+        self.mem[address as usize] = value;
+    }
+
+    fn irq_pending(&mut self) -> bool {
+        self.irq
+    }
+
+    fn irq_vector(&mut self) -> u16 {
+        0x1000
+    }
+}
+
+#[test]
+fn huc6280_taken_branch_costs_four_cycles() {
+    let mut cpu = CPU::new(TickBus::with_program(&[0xD0, 0x02]), Huc6280); // BNE +2
+    cpu.registers.status.remove(Status::PS_ZERO);
+
+    cpu.single_step();
+
+    assert_eq!(cpu.cycles, 4);
+    assert_eq!(cpu.registers.program_counter, 0x0004);
+}
+
+#[test]
+fn nmos_taken_branch_keeps_standard_three_cycle_timing() {
+    let mut cpu = CPU::new(TickBus::with_program(&[0xD0, 0x02]), Nmos6502); // BNE +2
+    cpu.registers.status.remove(Status::PS_ZERO);
+
+    cpu.single_step();
+
+    assert_eq!(cpu.cycles, 3);
+    assert_eq!(cpu.registers.program_counter, 0x0004);
+}
+
+#[test]
+fn huc6280_irq_dispatch_adds_eight_cycles() {
+    let mut bus = TickBus::with_program(&[0xEA]); // NOP
+    bus.irq = true;
+    bus.mem[0x1000] = 0x34;
+    bus.mem[0x1001] = 0x12;
+    let mut cpu = CPU::new(bus, Huc6280);
+    cpu.registers.status.remove(Status::PS_DISABLE_INTERRUPTS);
+
+    cpu.single_step();
+
+    assert_eq!(cpu.cycles, 10);
+    assert_eq!(cpu.registers.program_counter, 0x1234);
+}
+
+#[test]
+fn huc6280_block_transfer_ticks_each_byte() {
+    // TII $1000,$2000,$0002
+    let mut bus = TickBus::with_program(&[0x73, 0x00, 0x10, 0x00, 0x20, 0x02, 0x00]);
+    bus.mem[0x1000] = 0xAA;
+    bus.mem[0x1001] = 0x55;
+    let mut cpu = CPU::new(bus, Huc6280);
+
+    cpu.single_step();
+
+    assert_eq!(cpu.cycles, 29);
+    assert_eq!(cpu.memory.mem[0x2000], 0xAA);
+    assert_eq!(cpu.memory.mem[0x2001], 0x55);
+    assert_eq!(cpu.memory.ticks, [17, 6, 6]);
+}


### PR DESCRIPTION
So I'm not 100% certain that this is the right move, but I decided to put this PR up for discussions.

Basically, what I noticed is that my TurboGrafx emulator behaved weirdly: there were some sprite/background glitches I couldn't explain. At least in part, this is due to cycle timing issues in the 6502 emulator.

This PR is an attempt to account for those issues. Namely, extra cycles for branching and interrupts are accounted for now and I've simplified the cycle arithmetic to clean up the code a bit.